### PR TITLE
[Feat] 그룹 생성/수정 관련 수정

### DIFF
--- a/src/main/java/dnd/diary/controller/common/S3Controller.java
+++ b/src/main/java/dnd/diary/controller/common/S3Controller.java
@@ -20,9 +20,15 @@ public class S3Controller {
 
 	private final S3Service s3Service;
 
+	@PostMapping("/files")
+	public CustomResponseEntity<List<String>> uploadImageList(@RequestParam("images") List<MultipartFile> multipartFile) throws Exception {
+		List<String> fileImageList = s3Service.uploadImageList(multipartFile);
+		return CustomResponseEntity.success(fileImageList);
+	}
+
 	@PostMapping("/file")
-	public CustomResponseEntity<List<String>> upload(@RequestParam("images") List<MultipartFile> multipartFile) throws Exception {
-		List<String> fileImageList = s3Service.upload(multipartFile);
+	public CustomResponseEntity<String> uploadImage(@RequestParam("image") MultipartFile multipartFile) throws Exception {
+		String fileImageList = s3Service.uploadImage(multipartFile);
 		return CustomResponseEntity.success(fileImageList);
 	}
 

--- a/src/main/java/dnd/diary/controller/group/GroupController.java
+++ b/src/main/java/dnd/diary/controller/group/GroupController.java
@@ -7,6 +7,7 @@ import dnd.diary.response.group.*;
 import dnd.diary.service.group.GroupService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -19,15 +20,21 @@ public class GroupController {
 	private final GroupService groupService;
 
 	 @PostMapping("/create")
-	 public CustomResponseEntity<GroupCreateResponse> createGroup(@RequestBody GroupCreateRequest request) {
+	 public CustomResponseEntity<GroupCreateResponse> createGroup(
+	 		@RequestParam("image") MultipartFile multipartFile,
+	 		@RequestBody GroupCreateRequest request
+	 ) {
 		 groupValidator.checkGroupCreateAndUpdate(request.getGroupName(), request.getGroupNote());
-	 	return CustomResponseEntity.success(groupService.createGroup(request));
+	 	return CustomResponseEntity.success(groupService.createGroup(multipartFile, request));
 	 }
 
 	 @PatchMapping("/update")
-	public CustomResponseEntity<GroupUpdateResponse> updateGroup(@RequestBody GroupUpdateRequest request) {
+	public CustomResponseEntity<GroupUpdateResponse> updateGroup(
+			@RequestParam("image") MultipartFile multipartFile,
+			@RequestBody GroupUpdateRequest request
+	 ) {
 		 groupValidator.checkGroupCreateAndUpdate(request.getGroupName(), request.getGroupNote());
-		 return CustomResponseEntity.success(groupService.updateGroup(request));
+		 return CustomResponseEntity.success(groupService.updateGroup(multipartFile, request));
 	 }
 
 	 @DeleteMapping("/delete")

--- a/src/main/java/dnd/diary/domain/group/Group.java
+++ b/src/main/java/dnd/diary/domain/group/Group.java
@@ -12,6 +12,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -37,6 +38,8 @@ public class Group extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User groupCreateUser;
+
+    private LocalDateTime recentUpdatedAt;   // 게시물 최신 등록일
 
     // 그룹에 가입한 유저 정보
     @OneToMany(mappedBy = "group")
@@ -74,5 +77,9 @@ public class Group extends BaseEntity {
         this.groupName = groupName;
         this.groupNote = groupNote;
         this.groupImageUrl = groupImageUrl;
+    }
+
+    public void updateRecentModifiedAt(LocalDateTime recentUpdatedAt) {
+        this.recentUpdatedAt = recentUpdatedAt;
     }
 }

--- a/src/main/java/dnd/diary/enumeration/Result.java
+++ b/src/main/java/dnd/diary/enumeration/Result.java
@@ -13,7 +13,8 @@ public enum Result {
 	LOW_MIN_GROUP_NAME_LENGTH(2102, "그룹 이름 최소 글자(1자) 미만"),
 	HIGH_MAX_GROUP_NAME_LENGTH(2103, "그룹 이름 최대 글자(12자) 초과"),
 	HIGH_MAX_GROUP_NOTE_LENGTH(2104, "그룹 소개 최대 글자(30자) 초과"),
-	NO_USER_GROUP_LIST(2105, "가입한 그룹이 없는 경우");
+	NO_USER_GROUP_LIST(2105, "가입한 그룹이 없는 경우"),
+	FAIL_UPDATE_GROUP(2106, "방장만 그룹 수정 가능");
 
 	private final int code;
 	private final String message;

--- a/src/main/java/dnd/diary/response/group/GroupCreateResponse.java
+++ b/src/main/java/dnd/diary/response/group/GroupCreateResponse.java
@@ -15,6 +15,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class GroupCreateResponse {
+
     private Long groupId;
     private String groupName;
     private String groupNote;
@@ -27,8 +28,11 @@ public class GroupCreateResponse {
     @JsonFormat(pattern = "yyyy.MM.dd HH:mm:ss", timezone = "Asia/Seoul")
     private LocalDateTime groupModifiedAt;
 
+    @JsonFormat(pattern = "yyyy.MM.dd HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime recentUpdatedAt;   // 게시물 최신 등록일
+
     // 현재 그룹에 가입된 구성원 정보
-    private List<GroupMember> groupMemberList = new ArrayList<>();
+    private List<GroupCreateResponse.GroupMember> groupMemberList = new ArrayList<>();
 
     @Getter
     @Builder

--- a/src/main/java/dnd/diary/response/group/GroupUpdateResponse.java
+++ b/src/main/java/dnd/diary/response/group/GroupUpdateResponse.java
@@ -13,13 +13,20 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @AllArgsConstructor
 public class GroupUpdateResponse {
-	private Long groupId;
-	private String groupName;
-	private String groupNote;
-	private String groupImageUrl;
-	private Long groupCreateUserId;
-	@JsonFormat(pattern = "yyyy.MM.dd HH:mm:ss", timezone = "Asia/Seoul")
-	private LocalDateTime groupCreatedAt;
-	@JsonFormat(pattern = "yyyy.MM.dd HH:mm:ss", timezone = "Asia/Seoul")
-	private LocalDateTime groupModifiedAt;
+
+    private Long groupId;
+    private String groupName;
+    private String groupNote;
+    private String groupImageUrl;
+    private Long groupCreateUserId;
+
+    @JsonFormat(pattern = "yyyy.MM.dd HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime groupCreatedAt;
+
+    @JsonFormat(pattern = "yyyy.MM.dd HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime groupModifiedAt;
+
+    @JsonFormat(pattern = "yyyy.MM.dd HH:mm:ss", timezone = "Asia/Seoul")
+    private LocalDateTime recentUpdatedAt;   // 게시물 최신 등록일
+
 }

--- a/src/main/java/dnd/diary/service/content/ContentService.java
+++ b/src/main/java/dnd/diary/service/content/ContentService.java
@@ -28,6 +28,7 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -74,6 +75,9 @@ public class ContentService {
                         .group(group)
                         .build()
         );
+
+        // 그룹의 게시물 최신 등록일 업데이트
+        group.updateRecentModifiedAt(LocalDateTime.now());
 
         // forEach 구문을 통해 multipartFile로 넘어온 파일들 하나씩 fileNameList에 추가
         multipartFile.forEach(file -> {

--- a/src/main/java/dnd/diary/service/group/GroupService.java
+++ b/src/main/java/dnd/diary/service/group/GroupService.java
@@ -1,5 +1,6 @@
 package dnd.diary.service.group;
 
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import dnd.diary.domain.group.Group;
 import dnd.diary.domain.group.GroupStar;
 import dnd.diary.domain.group.GroupStarStatus;
@@ -15,9 +16,11 @@ import dnd.diary.repository.UserRepository;
 import dnd.diary.repository.group.UserJoinGroupRepository;
 import dnd.diary.response.group.*;
 import dnd.diary.service.UserService;
+import dnd.diary.service.s3.S3Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,10 +39,18 @@ public class GroupService {
 
 	private final UserService userService;
 	private final UserJoinGroupRepository userJoinGroupRepository;
+	private final S3Service s3Service;
 
-	public GroupCreateResponse createGroup(GroupCreateRequest request) {
+	public GroupCreateResponse createGroup(MultipartFile multipartFile, GroupCreateRequest request) {
 		User hostUser = findUser();
-		Group group = Group.toEntity(request.getGroupName(), request.getGroupNote(), request.getGroupImageUrl(), hostUser);
+
+		// 그룹 이미지 처리
+		String imageUrl = "";
+		if (multipartFile != null) {
+			imageUrl = s3Service.uploadImage(multipartFile);
+		}
+
+		Group group = Group.toEntity(request.getGroupName(), request.getGroupNote(), imageUrl, hostUser);
 		groupRepository.save(group);
 
 		// 그룹 생성자 가입 처리 추가
@@ -61,10 +72,18 @@ public class GroupService {
 				.build();
 	}
 
-	public GroupUpdateResponse updateGroup(GroupUpdateRequest request) {
+	public GroupUpdateResponse updateGroup(MultipartFile multipartFile, GroupUpdateRequest request) {
 		User user = findUser();
+
 		Group group = groupRepository.findById(request.getGroupId()).orElseThrow(() -> new CustomException(NOT_FOUND_GROUP));
-		group.update(request.getGroupName(), request.getGroupNote(), request.getGroupImageUrl());
+
+		String imageUrl = "";
+		// 그룹 이미지 추가 - 기존에 저장된 그룹 이미지와 동일한 경우 체크 제외
+		if (multipartFile != null) {
+			imageUrl = s3Service.uploadImage(multipartFile);
+		}
+
+		group.update(request.getGroupName(), request.getGroupNote(), imageUrl);
 
 		return GroupUpdateResponse.builder()
 			.groupId(group.getId())

--- a/src/main/java/dnd/diary/service/group/GroupService.java
+++ b/src/main/java/dnd/diary/service/group/GroupService.java
@@ -65,6 +65,7 @@ public class GroupService {
 				.groupCreateUserId(hostUser.getId())
 				.groupCreatedAt(group.getCreatedAt())
 				.groupModifiedAt(group.getModifiedAt())
+				.recentUpdatedAt(group.getRecentUpdatedAt())
 				.groupMemberList(List.of(
 						new GroupCreateResponse.GroupMember(hostUser.getId(), hostUser.getEmail(), hostUser.getNickName()
 							, updateHostUser.getCreatedAt()))
@@ -74,8 +75,12 @@ public class GroupService {
 
 	public GroupUpdateResponse updateGroup(MultipartFile multipartFile, GroupUpdateRequest request) {
 		User user = findUser();
-
 		Group group = groupRepository.findById(request.getGroupId()).orElseThrow(() -> new CustomException(NOT_FOUND_GROUP));
+
+		// 그룹 호스트 유저만 수정 가능
+		if (!group.getGroupCreateUser().getId().equals(user.getId())) {
+			throw new CustomException(FAIL_UPDATE_GROUP);
+		}
 
 		String imageUrl = "";
 		// 그룹 이미지 추가 - 기존에 저장된 그룹 이미지와 동일한 경우 체크 제외
@@ -93,6 +98,7 @@ public class GroupService {
 			.groupCreateUserId(user.getId())
 			.groupCreatedAt(group.getCreatedAt())
 			.groupModifiedAt(group.getModifiedAt())
+			.recentUpdatedAt(group.getRecentUpdatedAt())
 			.build();
 	}
 


### PR DESCRIPTION
- [Group 엔티티 게시물 최신 등록일 컬럼 추가 및 게시물 등록 시 최신 등록일 업데이트]
- [단일 이미지 업로드 API 추가]
- [그룹 생성/수정 시 그룹 이미지 request 형식 MultipartFile 로 변경]
- [그룹 생성/수정 response 수정, 그룹 방장이 아닌 유저의 수정 시 예외 처리 추가]