### PR TITLE
[Fix] Content 삭제 여부 컬럼 추가 및 게시물 생성/수정/삭제/조회 시 조건 추가

### DIFF
--- a/src/main/java/dnd/diary/domain/content/Content.java
+++ b/src/main/java/dnd/diary/domain/content/Content.java
@@ -53,6 +53,8 @@ public class Content extends BaseEntity {
     @Column(name = "delete_at", nullable = true)
     private LocalDateTime deleteAt;
 
+    private Boolean deletedYn;   // 게시물 삭제 여부
+
     // 게시물을 작성자
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -103,6 +105,10 @@ public class Content extends BaseEntity {
         this.latitude = latitude;
         this.longitude = longitude;
         this.location = location;
+    }
+
+    public void deleteContent() {
+        this.deletedYn = true;
     }
 
 }

--- a/src/main/java/dnd/diary/dto/content/ContentDto.java
+++ b/src/main/java/dnd/diary/dto/content/ContentDto.java
@@ -36,6 +36,7 @@ public class ContentDto {
         private LocalDateTime createAt;
         private long views;
         private String contentLink;
+        private Boolean deletedYn;
         private Long comments;
         private Long emotions;
         private Long emotionStatus;
@@ -60,6 +61,7 @@ public class ContentDto {
                     .createAt(content.getCreatedAt())
                     .views(Long.parseLong(views))
                     .contentLink(content.getContentLink())
+                    .deletedYn(content.getDeletedYn())
                     .comments((long) content.getComments().size())
                     .emotions((long) content.getEmotions().size())
                     .emotionStatus(emotionStatus)
@@ -193,6 +195,7 @@ public class ContentDto {
         private Boolean bookmarkAddStatus;
         private Long emotionStatus;
         private String contentLink;
+        private Boolean deletedYn;
         List<ContentDto.ImageResponseDto> collect;
 
         public static ContentDto.detailDto response(
@@ -210,6 +213,7 @@ public class ContentDto {
                     .location(content.getLocation())
                     .views(views)
                     .contentLink(content.getContentLink())
+                    .deletedYn(content.getDeletedYn())
                     .userId(content.getUser().getId())
                     .groupId(content.getGroup().getId())
                     .collect(collect)
@@ -236,6 +240,7 @@ public class ContentDto {
         private String location;
         private long views;
         private String contentLink;
+        private Boolean deletedYn;
         private Long userId;
         private Long groupId;
         List<ContentDto.ImageResponseDto> collect;
@@ -252,6 +257,7 @@ public class ContentDto {
                     .location(content.getLocation())
                     .views(views)
                     .contentLink(content.getContentLink())
+                    .deletedYn(content.getDeletedYn())
                     .userId(content.getUser().getId())
                     .groupId(content.getGroup().getId())
                     .collect(content.getContentImages()
@@ -277,6 +283,7 @@ public class ContentDto {
     @Builder
     public static class deleteContent {
         private Long contentid;
+        private Boolean deletedYn;
     }
 
     @AllArgsConstructor

--- a/src/main/java/dnd/diary/repository/content/ContentRepository.java
+++ b/src/main/java/dnd/diary/repository/content/ContentRepository.java
@@ -11,13 +11,23 @@ import java.util.Optional;
 
 @Repository
 public interface ContentRepository extends JpaRepository<Content, Long> {
-    Optional<Content> findByIdAndUserId(Long contentId, Long userId);
-    Page<Content> findByGroupId(Long groupId, Pageable pageable);
-    Page<Content> findByGroupIdIn(List<Long> groupId, Pageable pageable);
-    List<Content> findByIdIn(List<Long> contentId);
-    Page<Content> findByIdIn(List<Long> contentId, Pageable pageable);
-    Page<Content> findByUserId(Long userId, Pageable pageable);
-    Page<Content> findByContentContainingAndGroupIdIn(String word, List<Long> groupId, Pageable pageable);
-    List<Content> findByLocationAndGroupIdIn(String location, List<Long> groupId);
-    Long countByLocationAndGroupIdIn(String location, List<Long> groupId);
+//    Optional<Content> findByIdAndUserId(Long contentId, Long userId);
+//    Page<Content> findByGroupId(Long groupId, Pageable pageable);
+//    Page<Content> findByGroupIdIn(List<Long> groupId, Pageable pageable);
+//    List<Content> findByIdIn(List<Long> contentId);
+//    Page<Content> findByIdIn(List<Long> contentId, Pageable pageable);
+//    Page<Content> findByUserId(Long userId, Pageable pageable);
+//    Page<Content> findByContentContainingAndGroupIdIn(String word, List<Long> groupId, Pageable pageable);
+//    List<Content> findByLocationAndGroupIdIn(String location, List<Long> groupId);
+//    Long countByLocationAndGroupIdIn(String location, List<Long> groupId);
+
+    Optional<Content> findByIdAndUserIdAndDeletedYn(Long contentId, Long userId, Boolean deleteYn);
+    Page<Content> findByGroupIdAndDeletedYn(Long groupId, Boolean deleteYn, Pageable pageable);
+    Page<Content> findByGroupIdInAndDeletedYn(List<Long> groupId, Boolean deletedYn, Pageable pageable);
+    List<Content> findByIdInAndDeletedYn(List<Long> contentId, Boolean deletedYn);
+    Page<Content> findByIdInAndDeletedYn(List<Long> contentId, Boolean deletedYn, Pageable pageable);
+    Page<Content> findByUserIdAndDeletedYn(Long userId, Boolean deletedYn, Pageable pageable);
+    Page<Content> findByContentContainingAndGroupIdInAndDeletedYn(String word, List<Long> groupId, Boolean deletedYn, Pageable pageable);
+    List<Content> findByLocationAndGroupIdInAndDeletedYn(String location, List<Long> groupId, Boolean deletedYn);
+    Long countByLocationAndGroupIdInAndDeletedYn(String location, List<Long> groupId, Boolean deletedYn);
 }

--- a/src/main/java/dnd/diary/service/group/NotificationService.java
+++ b/src/main/java/dnd/diary/service/group/NotificationService.java
@@ -96,7 +96,7 @@ public class NotificationService {
 		List<AllNotificationListResponse.NotificationInfo> notificationInfoList = new ArrayList<>();
 		for (Notification notification : notificationList) {
 			if (notification.getNotificationType() == NotificationType.INVITE) {
-				if (notification.getInvite() == null) {
+				if (notification.getInvite() == null) {   // 초대 정보가 없는 알림인 경우
 					continue;
 				}
 				AllNotificationListResponse.NotificationInfo notificationInfo = new AllNotificationListResponse.NotificationInfo(notification);
@@ -121,10 +121,10 @@ public class NotificationService {
 				if (notification.getContent() == null || notification.getComment() == null) {
 					continue;
 				}
-				// 이미 삭제된 게시물일 경우 제외
-                if (notification.getContent().getDeleteAt() != null) {
-                    continue;
-                }
+				// 이미 삭제된 게시물일 경우에도 포함
+//                if (notification.getContent().getDeletedYn()) {
+//                    continue;
+//                }
 				Content content = notification.getContent();
 				Comment comment = notification.getComment();
 				AllNotificationListResponse.NotificationInfo notificationInfo = new AllNotificationListResponse.NotificationInfo(notification, content, comment);
@@ -149,10 +149,10 @@ public class NotificationService {
 				if (notification.getContent() == null || notification.getEmotion() == null) {
 					continue;
 				}
-                // 이미 삭제된 게시물일 경우
-                if (notification.getContent().getDeleteAt() != null) {
-                    continue;
-                }
+                // 이미 삭제된 게시물일 경우에도 포함
+//                if (notification.getContent().getDeletedYn()) {
+//                    continue;
+//                }
 				Content content = notification.getContent();
 				Emotion emotion = notification.getEmotion();
 				AllNotificationListResponse.NotificationInfo notificationInfo = new AllNotificationListResponse.NotificationInfo(notification, content, emotion);
@@ -177,7 +177,7 @@ public class NotificationService {
 					continue;
 				}
                 // 이미 삭제된 그룹일 경우 제외
-                if (notification.getGroup().isDeleted()) {
+                if (notification.getGroup().isDeleted()) {   // 이미 삭제된 그룹인 경우에도 포함
                     continue;
                 }
 				Group group = notification.getGroup();

--- a/src/main/java/dnd/diary/service/user/UserService.java
+++ b/src/main/java/dnd/diary/service/user/UserService.java
@@ -131,8 +131,8 @@ public class UserService {
 
         // 삭제된 게시글이 Exception을 일으키지 않도록 ContentId를 JPA로 얻어서 Content를 조회
         List<Long> contentIdList = bookmarkRepository.findContentIdList(getUser(userDetails.getUsername()).getId());
-        Page<Content> bookmarkPage = contentRepository.findByIdIn(
-                contentIdList, PageRequest.of(page - 1, 10, Sort.Direction.DESC, "createdAt")
+        Page<Content> bookmarkPage = contentRepository.findByIdInAndDeletedYn(
+                contentIdList, false, PageRequest.of(page - 1, 10, Sort.Direction.DESC, "createdAt")
         );
 
         return bookmarkPage.map((Content content) -> UserDto.BookmarkDto.response(
@@ -155,8 +155,8 @@ public class UserService {
         User user = getUser(userDetails.getUsername());
         List<Long> distinctContentIdListByUserId = commentRepository.findDistinctContentIdListByUserId(user.getId());
 
-        Page<Content> pageMyComment = contentRepository.findByIdIn(
-                distinctContentIdListByUserId, PageRequest.of(page - 1, 10, Sort.Direction.DESC, "createdAt")
+        Page<Content> pageMyComment = contentRepository.findByIdInAndDeletedYn(
+                distinctContentIdListByUserId, false, PageRequest.of(page - 1, 10, Sort.Direction.DESC, "createdAt")
         );
 
         return pageMyComment.map((Content content) ->
@@ -178,8 +178,8 @@ public class UserService {
                         () -> new CustomException(Result.FAIL)
                 );
 
-        Page<Content> pageMyContent = contentRepository.findByUserId(
-                user.getId(), PageRequest.of(page - 1, 10, Sort.Direction.DESC, "createdAt")
+        Page<Content> pageMyContent = contentRepository.findByUserIdAndDeletedYn(
+                user.getId(), false, PageRequest.of(page - 1, 10, Sort.Direction.DESC, "createdAt")
         );
 
         return pageMyContent.map((Content content) ->


### PR DESCRIPTION
- 기존에 Sofr delete 처리 된 게시물과 관련하여 오류 발생 및 알림 내 이전에 저장된 content 관련 알림 정보 조회 불가 이슈 존재`javax.persistence.EntityNotFoundException: Unable to find dnd.diary.domain.content.Content with id 135
`
- 이슈 발생 시 이전 버전으로 롤백